### PR TITLE
Add note about LED updates to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,21 @@ Tools for testing
 
 Since this module uses the input subsystem, you can use standard tools such as
 [evemu](http://cgit.freedesktop.org/evemu/) to test it.  Outputs are
-implemented using the leds subsystem and are consequently located in the
+implemented using the LED subsystem and are consequently located in the
 `/sys/class/leds` directory.  You can test these by echoing zero/nonzero values
 to the `brightness` file in a given led directory:
 
     echo 1 > /sys/class/leds/piuio::output3/brightness
 
+Note that for LEDs to update, there must be an active reader of the joystick
+(pad) input device, otherwise changes made to the LED pseudofiles will not
+affect a cab's lighting until the pads are next read from. That is, you may
+want to run something like this in another terminal when testing:
+
+    cat /dev/input/js0
+
+This will output binary garbage on every button / pad press, but will allow
+LEDs to update.
 
 Implementation and accuracy
 ---------------------------


### PR DESCRIPTION
LED updates are deferred to the next time pad/button input is polled, which makes testing a little bit wonky if you don't expect this.

I ran into this issue while converting an ITG cab, and it stumped me for a long time before I figured out what was going on. In talking to a friend who also converted an ITG cab a while back, it turned out they also had this issue (but ended up not resolving it).

I figured I would add a note about this in the README file, just in case it saves someone else some hours of scratching their head :)