### PR TITLE
Null dereference on Permission Application for Lights

### DIFF
--- a/mod/piuio.c
+++ b/mod/piuio.c
@@ -436,13 +436,12 @@ static int piuio_leds_init(struct piuio *piu)
 
 		/* Relax permissions on led attributes */
 		for (ag = piu->led[i].dev.dev->class->dev_groups; *ag; ag++) {
-			for (attr = (*ag)->attrs; *attr; attr++) {
-				ret = sysfs_chmod_file(&piu->led[i].dev.dev->kobj,
+			attr = (*piu->led[i].dev.dev->class->dev_groups)->attrs;
+			ret = sysfs_chmod_file(&piu->led[i].dev.dev->kobj,
 						*attr, S_IRUGO | S_IWUGO);
-				if (ret) {
-					led_classdev_unregister(&piu->led[i].dev);
-					goto out_unregister;
-				}
+			if (ret) {
+				led_classdev_unregister(&piu->led[i].dev);
+				goto out_unregister;
 			}
 		}
 	}


### PR DESCRIPTION
Hi there, not sure if this repo is maintained much, but I have been using this kernel module for quite some time.

I recently was working on some code on my main desktop and noticed that the module would have the following kernel oops when plugging in the piuio.

``` 8176.367803] BUG: kernel NULL pointer dereference, address: 0000000000000000
[ 8176.367806] #PF: supervisor read access in kernel mode
[ 8176.367807] #PF: error_code(0x0000) - not-present page
[ 8176.367808] PGD 0 P4D 0 
[ 8176.367810] Oops: 0000 [#1] PREEMPT SMP PTI
[ 8176.367813] CPU: 2 PID: 8867 Comm: kworker/2:2 Tainted: G           OE     5.9.14-arch1-1 #1
[ 8176.367814] Hardware name: MSI MS-7821/Z87-G45 GAMING (MS-7821), BIOS V1.9 07/21/2014
[ 8176.367818] Workqueue: usb_hub_wq hub_event
[ 8176.367822] RIP: 0010:piuio_probe+0x3a9/0x4e1 [piuio]
```

So according to the stack trace, that's the function that applies the permissions for the lighting in `/sys/class/leds`.

I ran into a similar issue when developing `hid-itgio` which I have published in my account, so I modified the function as follows.

I am currently running `5.9.14-arch1` so I am uncertain when this null pointer was going against the standard of the linux kernel, or if it is a recent addition, but this has been working for me and it allowed me to continue developing lighting drivers for stepmania.

Please let me know what you think or if you see any issues with the way that I modified the code.

Thank you for your work.