### PR TITLE
Fix null pointer dereference

### DIFF
--- a/mod/piuio.c
+++ b/mod/piuio.c
@@ -435,8 +435,8 @@ static int piuio_leds_init(struct piuio *piu)
 			goto out_unregister;
 
 		/* Relax permissions on led attributes */
-		for (ag = piu->led[i].dev.dev->class->dev_groups; *ag; ag++) {
-			for (attr = (*ag)->attrs; *attr; attr++) {
+		for (ag = piu->led[i].dev.dev->class->dev_groups; ag && *ag; ag++) {
+			for (attr = (*ag)->attrs; attr && *attr; attr++) {
 				ret = sysfs_chmod_file(&piu->led[i].dev.dev->kobj,
 						*attr, S_IRUGO | S_IWUGO);
 				if (ret) {


### PR DESCRIPTION
For some reason, line 439 was giving me a null pointer dereference when I didn't have my pads hooked up (possibly also when I did?  I didn't test that far).  This may also be related to doing a drastic update for my base computer.  I didn't try to narrow down exactly why.  This patch fixes the null pointer dereference; however, I do not know for certain that there isn't something *wrong* going on here that would require a bail instead of a skip.  After the patch my arcade's top buttons seem to function fine, and I haven't tested anything else.

This possibly addresses the same issue as #18 but in a different manner, but my dumb ass didn't find that PR or the other issue regarding it until after I manually hunted down the error and created a patch.